### PR TITLE
feat: Add static busybox bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,10 +25,7 @@ RUN set -x \
 # busybox-static usually installs /bin/busybox (static) on Alpine
 RUN set -eux \
   && cp /bin/busybox.static /bin/busybox \
-  && chmod 0755 /bin/busybox \
-  && rm -f /bin/sh \
-  && cp /bin/busybox /bin/sh \
-  && ln -sf /bin/busybox /bin/which
+  && chmod 0755 /bin/busybox
 
 # Upgrade all tools to avoid vulnerabilities
 RUN set -x && apk upgrade --no-cache --available

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,15 @@ RUN set -x \
         "https://dl.k8s.io/v1.34.1/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x /usr/bin/kubectl
 
-# Download BusyBox static binary (truly static, no musl/glibc deps)
-RUN set -x \
-    && curl -fsSL -o /bin/busybox \
-       "https://busybox.net/downloads/binaries/1.36.1-defconfig-multiarch-musl/busybox-x86_64" \
-    && chmod 0755 /bin/busybox \
-    && ln -sf /bin/busybox /bin/sh \
-    && ln -sf /bin/busybox /bin/which
+# Use the static busybox as /bin/sh and provide `which`
+# busybox-static usually installs /bin/busybox (static) on Alpine
+RUN set -eux \
+  && BB="$(command -v busybox || true)" \
+  && [ -n "$BB" ] \
+  && cp "$BB" /bin/busybox \
+  && chmod 0755 /bin/busybox \
+  && ln -sf /bin/busybox /bin/sh \
+  && ln -sf /bin/busybox /bin/which
 
 # Upgrade all tools to avoid vulnerabilities
 RUN set -x && apk upgrade --no-cache --available

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN set -x \
         curl \
         jq \
         bash \
+        busybox-static \
     && rm -rf /var/cache/apk/*
 
 ARG TARGETARCH
@@ -23,9 +24,7 @@ RUN set -x \
 # Use the static busybox as /bin/sh and provide `which`
 # busybox-static usually installs /bin/busybox (static) on Alpine
 RUN set -eux \
-  && BB="$(command -v busybox || true)" \
-  && [ -n "$BB" ] \
-  && cp "$BB" /bin/busybox \
+  && cp /bin/busybox.static /bin/busybox \
   && chmod 0755 /bin/busybox \
   && ln -sf /bin/busybox /bin/sh \
   && ln -sf /bin/busybox /bin/which

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ RUN set -x \
         "https://dl.k8s.io/v1.34.1/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x /usr/bin/kubectl
 
-# Use the static busybox as /bin/sh and provide `which`
-# busybox-static usually installs /bin/busybox (static) on Alpine
 RUN set -eux \
   && cp /bin/busybox.static /bin/busybox \
   && chmod 0755 /bin/busybox

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,14 @@ RUN set -x \
         "https://dl.k8s.io/v1.34.1/bin/linux/${TARGETARCH}/kubectl" \
     && chmod +x /usr/bin/kubectl
 
+# Download BusyBox static binary (truly static, no musl/glibc deps)
+RUN set -x \
+    && curl -fsSL -o /bin/busybox \
+       "https://busybox.net/downloads/binaries/1.36.1-defconfig-multiarch-musl/busybox-x86_64" \
+    && chmod 0755 /bin/busybox \
+    && ln -sf /bin/busybox /bin/sh \
+    && ln -sf /bin/busybox /bin/which
+
 # Upgrade all tools to avoid vulnerabilities
 RUN set -x && apk upgrade --no-cache --available
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN set -x \
 RUN set -eux \
   && cp /bin/busybox.static /bin/busybox \
   && chmod 0755 /bin/busybox \
-  && ln -sf /bin/busybox /bin/sh \
+  && rm -f /bin/sh \
+  && cp /bin/busybox /bin/sh \
   && ln -sf /bin/busybox /bin/which
 
 # Upgrade all tools to avoid vulnerabilities


### PR DESCRIPTION
Velero upgrade hook in charts expect to have static `/bin/sh`.

Added busybox binary with symlinks for `/bin/sh` and `/bin/which` using in velero chart.  